### PR TITLE
also add typeahead.bundle.min.js to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
             ],
             "files": [
                 "typeahead.min.js",
-                "typeahead.js"
+                "typeahead.js",
+                "typeahead.bundle.min.js"
             ]
         }
     }


### PR DESCRIPTION
This was the thing, I was looking for. `component.json` won't get used directly by composer.
