### PR TITLE
Fixing files referenced in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,12 @@
         "component": {
             "name": "typeaheadjs",
             "scripts": [
-                "typeahead.js"
+                "typeahead.bundle.min.js"
             ],
             "files": [
-                "typeahead.bundle.min.js"
+                "typeahead.bundle.min.js",
+                "typeahead.bundle.js",
+                "typeahead.jquery.js"
             ]
         }
     }


### PR DESCRIPTION
Typeahead.min.js is no more part of the repository. Changed extra.component.scripts to typeahead.bundle.min.js instead (it contains Bloodhound + Typeahead).
