### PR TITLE
Added the missing typeahead files to components.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,10 +4,13 @@
   "version": "0.10.5",
   "main": "typeahead.js",
   "scripts": [
-    "typeahead.js"
+    "typeahead.bundle.min.js"
   ],
    "files": [
-    "typeahead.bundle.min.js"
+    "typeahead.bundle.js",
+    "typeahead.bundle.min.js",
+    "typeahead.jquery.js",
+    "typeahead.jquery.min.js"
   ],
   "license": "MIT"
 }

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "typeaheadjs",
   "repo": "components/typeahead.js",
   "version": "0.10.5",
-  "main": "typeahead.js",
+  "main": "typeahead.bundle.min.js",
   "scripts": [
     "typeahead.bundle.min.js"
   ],

--- a/component.json
+++ b/component.json
@@ -12,5 +12,8 @@
     "typeahead.jquery.js",
     "typeahead.jquery.min.js"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "components/jquery": "*"
+  }
 }


### PR DESCRIPTION
The component.json file was broken as it was referring to an incorrect file.
